### PR TITLE
Closing the InteractiveSession opened at Line 48

### DIFF
--- a/jni-build/jni/include/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
+++ b/jni-build/jni/include/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py
@@ -172,7 +172,7 @@ def train():
         train_writer.add_summary(summary, i)
   train_writer.close()
   test_writer.close()
-
+  sess.close()
 
 def main(_):
   if tf.gfile.Exists(FLAGS.summaries_dir):


### PR DESCRIPTION
The InteractiveSession started at Line 48 is never closed. This pull request closes the InteractiveSession at Line 171 as the sess variable is no longer used after that